### PR TITLE
Fix failing toolchain resolution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,8 @@ workspace(name = "rules_clojure")
 load("@rules_clojure//:runtime.bzl", "clojure_runtime")
 clojure_runtime()
 
+register_toolchains("@rules_clojure//rules:clojure_toolchain")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 

--- a/runtime.bzl
+++ b/runtime.bzl
@@ -22,6 +22,3 @@ def clojure_runtime():
         server_urls = ["https://repo1.maven.org/maven2/"],
     )
 
-    native.register_toolchains(
-        "@rules_clojure//rules:clojure_toolchain",
-    )


### PR DESCRIPTION
`bazel test //...` was failing with
```
ERROR: While resolving toolchains for target //tests:library: no
matching toolchains found for types //rules:toolchain_type
ERROR: Analysis of target '//tests:library' failed; build aborted: no
matching toolchains found for types //rules:toolchain_type
```

For some reason it cannot be registered from macro.
I'll need to get back to this and cleanup toolchain/runtime setup