### PR TITLE
Use preinstalled bazel in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
         with:
           path: ~/.cache/bazel
           key: bazel
-      - name: Install bazelisk
-        run: |
-          curl "https://github.com/bazelbuild/bazelisk/releases/download/v1.5.0/bazelisk-linux-amd64" -L -o $HOME/bazelisk
-          chmod +x $HOME/bazelisk
       - name: Run bazel build
-        run: $HOME/bazelisk build //...
+        run: bazel build //...
       - name: Run bazel test
-        run: $HOME/bazelisk test //...
+        run: bazel test //...


### PR DESCRIPTION
I should have checked https://github.com/actions/virtual-environments/blob/ubuntu18/20200717.1/images/linux/Ubuntu1804-README.md before