### PR TITLE
Remove runtime.bzl and clojure_runtime() macro

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -24,3 +24,7 @@ def rules_clojure_dependencies():
 
 def rules_clojure_toolchains():
     native.register_toolchains("@rules_clojure//:clojure_toolchain")
+
+def rules_clojure_setup():
+    rules_clojure_dependencies()
+    rules_clojure_toolchains()

--- a/runtime.bzl
+++ b/runtime.bzl
@@ -1,5 +1,0 @@
-load("@rules_clojure//:repositories.bzl", "rules_clojure_dependencies", "rules_clojure_toolchains")
-
-def clojure_runtime():
-    rules_clojure_dependencies()
-    rules_clojure_toolchains()


### PR DESCRIPTION
**Note**: breaking change.

rules_clojure tries to follow recommended rule setup pattern.

Please check readme how to setup rules.

Example
```
load("@rules_clojure//:repositories.bzl", "rules_clojure_dependencies",
"rules_clojure_toolchains")

rules_clojure_dependencies()

rules_clojure_toolchains()
```
