### PR TITLE
Revert runtime.bzl

### DIFF
--- a/runtime.bzl
+++ b/runtime.bzl
@@ -1,0 +1,13 @@
+load("@rules_clojure//:repositories.bzl", "rules_clojure_dependencies", "rules_clojure_toolchains")
+
+def clojure_runtime():
+    """deprecated
+
+    Please replace this macro with:
+
+    load("@rules_clojure//:repositories.bzl", "rules_clojure_dependencies", "rules_clojure_toolchains")
+    rules_clojure_dependencies()
+    rules_clojure_toolchains()
+    """
+    rules_clojure_dependencies()
+    rules_clojure_toolchains()


### PR DESCRIPTION
Add runtime.bzl back with deprecation message. Need to think what is better/concise way to setup rule set.

I'm not sure I like recommended pattern but runtime.bzl isn't good as well