### PR TITLE
Add clojure_java_library rule

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -1,4 +1,5 @@
 load("@rules_clojure//rules:binary.bzl", _clojure_binary_impl = "clojure_binary_impl")
+load("@rules_clojure//rules:compile.bzl", _clojure_java_library_impl = "clojure_java_library_impl")
 load("@rules_clojure//rules:library.bzl", _clojure_library_impl = "clojure_library_impl")
 load("@rules_clojure//rules:repl.bzl", _clojure_repl_impl = "clojure_repl_impl")
 load("@rules_clojure//rules:test.bzl", _clojure_test_impl = "clojure_test_impl")
@@ -12,6 +13,17 @@ clojure_binary = rule(
     executable = True,
     toolchains = ["@rules_clojure//:toolchain"],
     implementation = _clojure_binary_impl,
+)
+
+clojure_java_library = rule(
+    doc = "Compiles given namespaces to java.",
+    attrs = {
+        "namespaces": attr.string_list(mandatory = True, allow_empty = False, doc = "Namespaces in classpath to compile."),
+        "deps": attr.label_list(mandatory = True, allow_empty = False, providers = [JavaInfo], doc = "Dependencies to compile."),
+    },
+    provides = [JavaInfo],
+    toolchains = ["@rules_clojure//:toolchain"],
+    implementation = _clojure_java_library_impl,
 )
 
 clojure_library = rule(

--- a/rules/compile.bzl
+++ b/rules/compile.bzl
@@ -1,0 +1,44 @@
+def clojure_java_library_impl(ctx):
+    toolchain = ctx.toolchains["@rules_clojure//:toolchain"]
+
+    output = ctx.actions.declare_directory("%s.classes" % ctx.label.name)
+    jar = ctx.actions.declare_file("%s.jar" % ctx.label.name)
+
+    deps = depset(
+        direct = toolchain.files.runtime,
+        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps],
+    )
+
+    cmd = """
+        set -e;
+        rm -rf {output}
+        mkdir -p {output}
+        {java} -cp {classpath} -Dclojure.compile.path={output} -Dclojure.compile.jar={jar} -Dclojure.compile.aot={aot} clojure.main {script}
+    """.format(
+        java = toolchain.java,
+        classpath = ":".join([f.path for f in deps.to_list() + [output]]),
+        output = output.path,
+        jar = jar.path,
+        aot = ",".join(ctx.attr.namespaces),
+        script = toolchain.scripts["compile.clj"].path,
+    )
+
+    ctx.actions.run_shell(
+        command = cmd,
+        outputs = [output, jar],
+        inputs = deps.to_list() + toolchain.files.scripts + toolchain.files.jdk,
+        mnemonic = "ClojureJavaLibrary",
+        progress_message = "Compiling clojure to java for %s" % ctx.label,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([jar]),
+        ),
+        JavaInfo(
+            output_jar = jar,
+            compile_jar = jar,
+            source_jar = None,
+            deps = [dep[JavaInfo] for dep in toolchain.runtime + ctx.attr.deps],
+        ),
+    ]

--- a/scripts/compile.clj
+++ b/scripts/compile.clj
@@ -1,0 +1,30 @@
+(require '[clojure.java.io :as io])
+(import (java.io PushbackReader BufferedOutputStream FileOutputStream))
+(import (java.util.jar Manifest JarEntry JarFile JarOutputStream))
+
+(def compile-dir (-> "clojure.compile.path" System/getProperty io/file))
+(def compile-jar (-> "clojure.compile.jar" System/getProperty io/file))
+(def compile-aot (-> "clojure.compile.aot" System/getProperty or (.split ",") (->> (filter not-empty) (map symbol))))
+
+(def manifest
+  (let [m (Manifest.)]
+    (doto (.getMainAttributes m)
+      (.putValue "Manifest-Version" "1.0"))
+    m))
+
+(defn put-next-entry! [target name]
+  (.putNextEntry target (doto (JarEntry. name) (.setTime 0))))
+
+(doseq [namespace compile-aot]
+  (compile namespace))
+
+(with-open [jar-os (-> compile-jar FileOutputStream. BufferedOutputStream. JarOutputStream.)]
+  (put-next-entry! jar-os JarFile/MANIFEST_NAME)
+  (.write manifest jar-os)
+  (.closeEntry jar-os)
+  (doseq [file (file-seq compile-dir)
+          :when (.isFile file)
+          :let [name (.replaceFirst (str file) (str compile-dir "/") "")]]
+    (put-next-entry! jar-os name)
+    (io/copy file jar-os)
+    (.closeEntry jar-os)))

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -233,7 +233,7 @@ sh_test(
 # TODO: Do we need multiple namespaces and dependencies since clojure compiles everything transitively?
 
 clojure_library(
-    name = "lib", # didn't reuse :library because it has aot I'll do so once aot is removed
+    name = "lib",  # didn't reuse :library because it has aot I'll do so once aot is removed
     srcs = ["library.clj"],
 )
 
@@ -269,8 +269,9 @@ clojure_java_library(
 
 clojure_test(
     name = "app-bundled-java-test",
+    size = "small",
     srcs = ["app-java-test.clj"],
-    deps = [":app-bundled-java"]
+    deps = [":app-bundled-java"],
 )
 
 java_binary(
@@ -299,8 +300,9 @@ clojure_java_library(
 
 clojure_test(
     name = "app-transitive-java-test",
+    size = "small",
     srcs = ["app-java-test.clj"],
-    deps = [":app-transitive-java"]
+    deps = [":app-transitive-java"],
 )
 
 java_binary(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,5 @@
-load("@rules_clojure//:rules.bzl", "clojure_binary", "clojure_library", "clojure_repl", "clojure_test")
+load("@rules_clojure//:rules.bzl", "clojure_binary", "clojure_java_library", "clojure_library", "clojure_repl", "clojure_test")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 clojure_test(
     name = "unconditionally-passing-test",
@@ -224,4 +225,98 @@ sh_test(
         """'app main library input'""",
     ],
     data = [":app-bundled-binary"],
+)
+
+# AOT with clojure_java_library
+# TODO: Move to aot package
+# TODO: Add tests for multiple namespaces and multiple dependencies
+# TODO: Do we need multiple namespaces and dependencies since clojure compiles everything transitively?
+
+clojure_library(
+    name = "lib", # didn't reuse :library because it has aot I'll do so once aot is removed
+    srcs = ["library.clj"],
+)
+
+clojure_java_library(
+    name = "library-java",
+    namespaces = ["tests.library"],
+    deps = [":lib"],
+)
+
+java_binary(
+    name = "library-java-binary",
+    main_class = "tests.library",
+    runtime_deps = [":library-java"],
+)
+
+sh_test(
+    name = "library-java-binary-test",
+    size = "small",
+    srcs = ["assert/binary.sh"],
+    args = [
+        "$(location :library-java-binary)",
+        """input""",
+        """'library main input'""",
+    ],
+    data = [":library-java-binary"],
+)
+
+clojure_java_library(
+    name = "app-bundled-java",
+    namespaces = ["tests.app"],
+    deps = [":app-bundled"],
+)
+
+clojure_test(
+    name = "app-bundled-java-test",
+    srcs = ["app-java-test.clj"],
+    deps = [":app-bundled-java"]
+)
+
+java_binary(
+    name = "app-bundled-java-binary",
+    main_class = "aot.CompiledAppClass",
+    runtime_deps = [":app-bundled-java"],
+)
+
+sh_test(
+    name = "app-bundled-java-binary-test",
+    size = "small",
+    srcs = ["assert/binary.sh"],
+    args = [
+        "$(location :app-bundled-java-binary)",
+        """input""",
+        """'app main library input'""",
+    ],
+    data = [":app-bundled-java-binary"],
+)
+
+clojure_java_library(
+    name = "app-transitive-java",
+    namespaces = ["tests.app"],
+    deps = [":app-transitive"],
+)
+
+clojure_test(
+    name = "app-transitive-java-test",
+    srcs = ["app-java-test.clj"],
+    deps = [":app-transitive-java"]
+)
+
+java_binary(
+    name = "app-transitive-java-binary",
+    main_class = "aot.CompiledAppClass",
+    runtime_deps = [":app-transitive-java"],
+)
+
+sh_test(
+    name = "app-transitive-java-binary-test",
+    size = "small",
+    srcs = ["assert/binary.sh"],
+    args = [
+        "$(location :app-transitive-java-binary)",
+        """input""",
+        """'app main library input'""",
+    ],
+    data = [":app-transitive-java-binary"],
 )

--- a/tests/app-java-test.clj
+++ b/tests/app-java-test.clj
@@ -1,0 +1,7 @@
+(ns tests.app-java-test
+    (:import aot.CompiledAppClass)
+    (:use clojure.test))
+
+(deftest app-java
+    (is (= (.getName CompiledAppClass) "aot.CompiledAppClass"))
+    (is (= (.getSuperclass CompiledAppClass) java.lang.Object)))

--- a/tests/app.clj
+++ b/tests/app.clj
@@ -1,7 +1,8 @@
 (ns tests.app
+    (:gen-class :name aot.CompiledAppClass)
     (:require [tests.library :as lib])
     (:use clojure.test))
 
 (defn echo [message] (str "app " (lib/echo message)))
 
-(defn -main [& args] (print "app main" (lib/echo (apply str args))))
+(defn -main [& args] (println "app main" (lib/echo (apply str args))))

--- a/tests/library.clj
+++ b/tests/library.clj
@@ -2,4 +2,4 @@
 
 (defn echo [message] (str "library " message))
 
-(defn -main [& args] (print "library main" (apply str args)))
+(defn -main [& args] (println "library main" (apply str args)))


### PR DESCRIPTION
Having aots in clojure_library might be not the best idea.

For regular clojure flow you shouldn't need to compile to java anything.
If you decide that you need shift from clojure to java it should be stated explicitly. (Usually it's for deployment and interop)
Problem with aots in clojure_library is that compile is eager. There is a mismatch were clojure_library should bundle only direct sources but with aot option library suddenly contains all transitive namespaces compiled.
Separate rule would give an ability to tune compile options per target (not implemented)