### PR TITLE
Use host path separator

### DIFF
--- a/rules/binary.bzl
+++ b/rules/binary.bzl
@@ -10,7 +10,7 @@ def clojure_binary_impl(ctx):
         output = ctx.outputs.executable,
         content = "{java} -cp {classpath} clojure.main -m {main} $@".format(
             java = toolchain.java_runfiles,
-            classpath = ":".join([f.short_path for f in deps.to_list()]),
+            classpath = ctx.configuration.host_path_separator.join([f.short_path for f in deps.to_list()]),
             main = ctx.attr.main,
         ),
     )

--- a/rules/compile.bzl
+++ b/rules/compile.bzl
@@ -16,7 +16,7 @@ def clojure_java_library_impl(ctx):
         {java} -cp {classpath} -Dclojure.compile.path={classes} -Dclojure.compile.jar={jar} clojure.main {script} {namespaces}
     """.format(
         java = toolchain.java,
-        classpath = ":".join([f.path for f in deps.to_list() + [classes]]),
+        classpath = ctx.configuration.host_path_separator.join([f.path for f in deps.to_list() + [classes]]),
         classes = classes.path,
         jar = jar.path,
         script = toolchain.scripts["compile.clj"].path,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -5,7 +5,7 @@ def clojure_library_impl(ctx):
 
     cmd = "{java} -cp {classpath} -Dclojure.compile.jar={jar} clojure.main {script} {sources}".format(
         java = toolchain.java,
-        classpath = ":".join([f.path for f in toolchain.files.runtime]),
+        classpath = ctx.configuration.host_path_separator.join([f.path for f in toolchain.files.runtime]),
         jar = jar.path,
         script = toolchain.scripts["library.clj"].path,
         sources = " ".join([f.path for f in ctx.files.srcs]),

--- a/rules/repl.bzl
+++ b/rules/repl.bzl
@@ -10,7 +10,7 @@ def clojure_repl_impl(ctx):
         output = ctx.outputs.executable,
         content = "{java} -cp {classpath} clojure.main {args}".format(
             java = toolchain.java_runfiles,
-            classpath = ":".join([f.short_path for f in deps.to_list()]),
+            classpath = ctx.configuration.host_path_separator.join([f.short_path for f in deps.to_list()]),
             args = " ".join(["-e", """\"(require '[{ns}]) (in-ns '{ns}) (clojure.main/repl)\"""".format(ns = ctx.attr.ns)] if ctx.attr.ns else []),
         ),
     )

--- a/rules/test.bzl
+++ b/rules/test.bzl
@@ -10,7 +10,7 @@ def clojure_test_impl(ctx):
         output = ctx.outputs.executable,
         content = "{java} -cp {classpath} clojure.main {script} {sources}".format(
             java = toolchain.java_runfiles,
-            classpath = ":".join([f.short_path for f in deps.to_list()]),
+            classpath = ctx.configuration.host_path_separator.join([f.short_path for f in deps.to_list()]),
             script = toolchain.scripts["test.clj"].path,
             sources = " ".join([f.path for f in ctx.files.srcs]),
         ),


### PR DESCRIPTION
Required for Windows compatibility, since Windows' path separator is ":" and not ";".  Pretty sure this (constructing java classpaths) is the reason that `ctx.configuration.host_path_separator` even exists, e.g.  how they do this in the default java rules: https://github.com/bazelbuild/bazel/blob/91483e8c967cc9867d8a1e28f5eaabc1ee5facfb/tools/jdk/default_java_toolchain.bzl#L243